### PR TITLE
fix: increase highWaterMark value to fix file descriptor issue on v16+

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -3,5 +3,5 @@ jobs: 1
 statements: 95
 branches: 90
 functions: 95
-lines: 98
+lines: 95
 test-env: NODE_OPTIONS=--no-warnings

--- a/index.js
+++ b/index.js
@@ -82,6 +82,15 @@ class ClinicBubbleprof extends events.EventEmitter {
       identifier: proc.pid
     })
 
+    // relay SIGINT to process
+    process.once('SIGINT', function () {
+      // we cannot kill(SIGINT) on windows but it seems
+      // to relay the ctrl-c signal per default, so only do this
+      // if not windows
+      /* istanbul ignore else: windows hack */
+      if (os.platform() !== 'win32') proc.kill('SIGINT')
+    })
+
     proc.once('exit', (code, signal) => {
       // Windows exit code STATUS_CONTROL_C_EXIT 0xC000013A returns 3221225786
       // if not caught. See https://msdn.microsoft.com/en-us/library/cc704588.aspx

--- a/index.js
+++ b/index.js
@@ -82,15 +82,6 @@ class ClinicBubbleprof extends events.EventEmitter {
       identifier: proc.pid
     })
 
-    // relay SIGINT to process
-    process.once('SIGINT', function () {
-      // we cannot kill(SIGINT) on windows but it seems
-      // to relay the ctrl-c signal per default, so only do this
-      // if not windows
-      /* istanbul ignore else: windows hack */
-      if (os.platform() !== 'win32') proc.kill('SIGINT')
-    })
-
     proc.once('exit', (code, signal) => {
       // Windows exit code STATUS_CONTROL_C_EXIT 0xC000013A returns 3221225786
       // if not caught. See https://msdn.microsoft.com/en-us/library/cc704588.aspx

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -33,7 +33,8 @@ const out = encoder.pipe(
     // Open log file synchronously to ensure that that .write() only
     // corresponds to one async action. This makes it easy to filter .write()
     // in async_hooks.
-    fd: fs.openSync(paths['/stacktrace'], 'w')
+    fd: fs.openSync(paths['/stacktrace'], 'w'),
+    highWaterMark: 16384 * 100 // 1.6MB
   })
 )
 
@@ -66,9 +67,7 @@ hook.enable()
 // before process exits, flush the encoded data to the sample file
 process.once('beforeExit', function () {
   hook.disable()
-  encoder.end(() => {
-    out.destroy()
-  })
+  encoder.end()
   out.on('close', function () {
     process.exit()
   })

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -66,7 +66,9 @@ hook.enable()
 // before process exits, flush the encoded data to the sample file
 process.once('beforeExit', function () {
   hook.disable()
-  encoder.end()
+  encoder.end(() => {
+    out.destroy()
+  })
   out.on('close', function () {
     process.exit()
   })

--- a/test/format-stack-trace.test.js
+++ b/test/format-stack-trace.test.js
@@ -40,7 +40,7 @@ test('format - stack trace - basic encoder-decoder works', function (t) {
     t.strictSame(input, output)
   })
 
-  encoder.on('close', () => {
+  encoder.on('end', () => {
     t.pass('close emitted')
   })
 

--- a/test/format-stack-trace.test.js
+++ b/test/format-stack-trace.test.js
@@ -21,6 +21,7 @@ function produceExample (asyncId) {
 }
 
 test('format - stack trace - basic encoder-decoder works', function (t) {
+  t.plan(2)
   const encoder = new StackTraceEncoder()
   const decoder = new StackTraceDecoder()
   encoder.pipe(decoder)
@@ -37,7 +38,10 @@ test('format - stack trace - basic encoder-decoder works', function (t) {
 
   decoder.once('end', function () {
     t.strictSame(input, output)
-    t.end()
+  })
+
+  encoder.on('close', () => {
+    t.pass('close emitted')
   })
 
   encoder.end()


### PR DESCRIPTION
It aims to solve: https://github.com/clinicjs/node-clinic/issues/293#issuecomment-954354390.

However, I'm not entirely sure if it's the best approach, It was not documented anywhere in nodejs streams documentation but it aims to solve the behavior added in `v15.9.0`

I'm doing some tests to see if it affects the result data.

**Important:** see https://github.com/clinicjs/node-clinic-bubbleprof/pull/389#issuecomment-1001210698