### PR TITLE
update: remove deprecation warning on v17.2+

### DIFF
--- a/collect/system-info.js
+++ b/collect/system-info.js
@@ -2,7 +2,14 @@
 
 const path = require('path')
 const Module = require('module')
-const asyncWrap = process.binding('async_wrap') // eslint-disable-line node/no-deprecated-api
+const semver = require('semver')
+let asyncWrap
+
+if (semver.gte(process.version, '17.2.0')) {
+  asyncWrap = { Providers: require('async_hooks').asyncWrapProviders }
+} else {
+  asyncWrap = process.binding('async_wrap') // eslint-disable-line node/no-deprecated-api
+}
 
 function getMainDirectory () {
   if (process._eval != null) return process.cwd()

--- a/collect/system-info.js
+++ b/collect/system-info.js
@@ -2,11 +2,11 @@
 
 const path = require('path')
 const Module = require('module')
-const semver = require('semver')
+const wrapProviders = require('async_hooks').asyncWrapProviders
 let asyncWrap
 
-if (semver.gte(process.version, '17.2.0')) {
-  asyncWrap = { Providers: require('async_hooks').asyncWrapProviders }
+if (wrapProviders) {
+  asyncWrap = { Providers: wrapProviders }
 } else {
   asyncWrap = process.binding('async_wrap') // eslint-disable-line node/no-deprecated-api
 }


### PR DESCRIPTION
Address: #383 

The `asyncWrapProviders` wasn't backported to v16 yet, once it's done a new PR will be created.